### PR TITLE
言及機能の実装

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'uri'
-
 class ReportsController < ApplicationController
   before_action :set_report, only: %i[edit update destroy]
 
@@ -22,6 +20,7 @@ class ReportsController < ApplicationController
 
   def create
     @report = current_user.reports.new(report_params)
+
     if @report.save
       redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
     else

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -22,9 +22,6 @@ class ReportsController < ApplicationController
 
   def create
     @report = current_user.reports.new(report_params)
-
-    str = @report.content
-    @report.mention_url_check(str)
     if @report.save
       redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
     else
@@ -33,14 +30,11 @@ class ReportsController < ApplicationController
   end
 
   def update
-    str = report_params[:content]
-    ActiveRecord::Base.transaction do
-      @report.mention_url_check(str)
-      @report.update!(report_params)
+    if @report.update(report_params)
+      redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
+    else
+      render :edit, status: :unprocessable_entity
     end
-    redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
-  rescue ActiveRecord::RecordInvalid
-    render :edit, status: :unprocessable_entity
   end
 
   def destroy

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'uri'
+
 class ReportsController < ApplicationController
   before_action :set_report, only: %i[edit update destroy]
 
@@ -21,6 +23,8 @@ class ReportsController < ApplicationController
   def create
     @report = current_user.reports.new(report_params)
 
+    str = @report.content
+    mention_url_check(@report, str)
     if @report.save
       redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
     else
@@ -29,11 +33,15 @@ class ReportsController < ApplicationController
   end
 
   def update
-    if @report.update(report_params)
-      redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
-    else
-      render :edit, status: :unprocessable_entity
+    str = report_params[:content]
+    mention_url_check(@report, str)
+    ActiveRecord::Base.transaction do
+      @report.update!(report_params)
+      @report.mentioning_report_ids = mention_url_check(@report, str)
     end
+    redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
+  rescue ActiveRecord::RecordInvalid
+    render :edit, status: :unprocessable_entity
   end
 
   def destroy
@@ -50,5 +58,17 @@ class ReportsController < ApplicationController
 
   def report_params
     params.require(:report).permit(:title, :content)
+  end
+
+  def mention_url_check(report, str)
+    check_url = 'http://localhost:3000/reports/'
+    report_url_check = URI.extract(str, ['http']).uniq.select { |url| url.start_with?(check_url) }
+    repo_ids = report_url_check.map { |url| url.gsub(check_url, '').to_i }
+    existing_ids = repo_ids.select { |repo_id| Report.find_by(id: repo_id) }
+
+    return existing_ids if Report.exists?(report.id)
+
+    existing_ids = existing_ids.map { |id| { mentioned_id: id } }
+    report.mentioning_relationships.build(existing_ids)
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -24,7 +24,7 @@ class ReportsController < ApplicationController
     @report = current_user.reports.new(report_params)
 
     str = @report.content
-    mention_url_check(@report, str)
+    @report.mention_url_check(str)
     if @report.save
       redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
     else
@@ -34,10 +34,9 @@ class ReportsController < ApplicationController
 
   def update
     str = report_params[:content]
-    mention_url_check(@report, str)
     ActiveRecord::Base.transaction do
+      @report.mention_url_check(str)
       @report.update!(report_params)
-      @report.mentioning_report_ids = mention_url_check(@report, str)
     end
     redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
   rescue ActiveRecord::RecordInvalid
@@ -58,17 +57,5 @@ class ReportsController < ApplicationController
 
   def report_params
     params.require(:report).permit(:title, :content)
-  end
-
-  def mention_url_check(report, str)
-    check_url = 'http://localhost:3000/reports/'
-    report_url_check = URI.extract(str, ['http']).uniq.select { |url| url.start_with?(check_url) }
-    repo_ids = report_url_check.map { |url| url.gsub(check_url, '').to_i }
-    existing_ids = repo_ids.select { |repo_id| Report.find_by(id: repo_id) }
-
-    return existing_ids if Report.exists?(report.id)
-
-    existing_ids = existing_ids.map { |id| { mentioned_id: id } }
-    report.mentioning_relationships.build(existing_ids)
   end
 end

--- a/app/models/mention.rb
+++ b/app/models/mention.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Mention < ApplicationRecord
+  belongs_to :mentioning, class_name: 'Report', inverse_of: :mentioning_relationships
+  belongs_to :mentioned, class_name: 'Report', inverse_of: :mentioned_relationships
+end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -4,6 +4,12 @@ class Report < ApplicationRecord
   belongs_to :user
   has_many :comments, as: :commentable, dependent: :destroy
 
+  has_many :mentioning_relationships, class_name: 'Mention', foreign_key: 'mentioning_id', dependent: :destroy, inverse_of: :mentioning
+  has_many :mentioning_reports, through: :mentioning_relationships, source: :mentioned
+
+  has_many :mentioned_relationships, class_name: 'Mention', foreign_key: 'mentioned_id', dependent: :destroy, inverse_of: :mentioned
+  has_many :mentioned_reports, through: :mentioned_relationships, source: :mentioning
+
   validates :title, presence: true
   validates :content, presence: true
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Report < ApplicationRecord
+  before_save :set_mention
+
   belongs_to :user
   has_many :comments, as: :commentable, dependent: :destroy
 
@@ -21,7 +23,7 @@ class Report < ApplicationRecord
     created_at.to_date
   end
 
-  def mention_url_check(str)
+  def build_mention(str)
     mentioning_reports.destroy_all if mentioning_reports.exists?
     check_url = 'http://localhost:3000/reports/'
     report_url_check = URI.extract(str, ['http']).uniq.select { |url| url.start_with?(check_url) }
@@ -32,5 +34,11 @@ class Report < ApplicationRecord
     existing_ids = Report.where(id: repo_ids).pluck(:id)
     existing_ids = existing_ids.map { |id| { mentioned_id: id } }
     mentioning_relationships.build(existing_ids)
+  end
+
+  private
+
+  def set_mention
+    build_mention(content)
   end
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -20,4 +20,17 @@ class Report < ApplicationRecord
   def created_on
     created_at.to_date
   end
+
+  def mention_url_check(str)
+    mentioning_reports.destroy_all if mentioning_reports.exists?
+    check_url = 'http://localhost:3000/reports/'
+    report_url_check = URI.extract(str, ['http']).uniq.select { |url| url.start_with?(check_url) }
+
+    repo_ids = report_url_check.map { |url| url.gsub(check_url, '').to_i }
+    repo_ids.delete(id)
+
+    existing_ids = Report.where(id: repo_ids).pluck(:id)
+    existing_ids = existing_ids.map { |id| { mentioned_id: id } }
+    mentioning_relationships.build(existing_ids)
+  end
 end

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -4,6 +4,8 @@
   <%= render @report %>
 </div>
 
+<%= render 'shared/mentions' %>
+
 <%= render 'shared/comments', commentable: @report %>
 
 <nav class="page-nav">

--- a/app/views/shared/_mentions.html.erb
+++ b/app/views/shared/_mentions.html.erb
@@ -1,0 +1,9 @@
+<ul>
+  <p><%= t('shared.mention.message.link') unless @report.mentioned_report_ids == [] %></p>
+  <% @report.mentioned_report_ids.each do |repo_id| %>
+    <li><% repo = Report.find(repo_id) %>
+    [ <%= repo.user.name_or_email %> ]
+    <%= link_to "#{repo.title}", report_path(repo.id) %>
+    - <%= l( repo.created_on, format: :long ) %>
+  <% end %>
+</ul>

--- a/app/views/shared/_mentions.html.erb
+++ b/app/views/shared/_mentions.html.erb
@@ -1,7 +1,7 @@
 <ul>
-  <p><%= t('shared.mention.message.link') unless @report.mentioned_report_ids == [] %></p>
-  <% @report.mentioned_report_ids.each do |repo_id| %>
-    <li><% repo = Report.find(repo_id) %>
+  <p><%= t('shared.mention.message.link') if @report.mentioned_reports.exists? %></p>
+  <% @report.mentioned_reports.order(:created_at).each do |repo| %>
+    <li>
     [ <%= repo.user.name_or_email %> ]
     <%= link_to "#{repo.title}", report_path(repo.id) %>
     - <%= l( repo.created_on, format: :long ) %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -212,6 +212,9 @@ ja:
       menu: メニュー
       sign_in_as: "%{user} としてログイン中"
   shared:
+    mention:
+      message: 
+        link: この日報は以下の日報からリンクされています
     comments:
       create: コメントする
       delete: 削除

--- a/db/migrate/20250911102300_create_mentions.rb
+++ b/db/migrate/20250911102300_create_mentions.rb
@@ -1,0 +1,12 @@
+class CreateMentions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :mentions do |t|
+      t.references :mentioning, null: false, foreign_key: { to_table: :reports }
+      t.references :mentioned, null: false, foreign_key: { to_table: :reports }
+
+      t.timestamps
+    end
+    add_index :mentions, [:mentioning_id, :mentioned_id], unique: true
+  end
+end
+

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_02_082433) do
+ActiveRecord::Schema[7.0].define(version: 2025_09_11_102300) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -59,6 +59,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_02_082433) do
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
+  create_table "mentions", force: :cascade do |t|
+    t.integer "mentioning_id", null: false
+    t.integer "mentioned_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["mentioned_id"], name: "index_mentions_on_mentioned_id"
+    t.index ["mentioning_id", "mentioned_id"], name: "index_mentions_on_mentioning_id_and_mentioned_id", unique: true
+    t.index ["mentioning_id"], name: "index_mentions_on_mentioning_id"
+  end
+
   create_table "reports", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "title", null: false
@@ -87,5 +97,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_02_082433) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "comments", "users"
+  add_foreign_key "mentions", "reports", column: "mentioned_id"
+  add_foreign_key "mentions", "reports", column: "mentioning_id"
   add_foreign_key "reports", "users"
 end


### PR DESCRIPTION
日報の言及機能をアプリに追加しました。
日報の内容にすでに作成してある`http://localhost:3000/reports/:id`が含まれていると
`:id`に該当する日報に作成した日報へのリンクが表示されます。